### PR TITLE
Untested hotfix for random swaps etc.

### DIFF
--- a/GuruShitsAutoLike.js
+++ b/GuruShitsAutoLike.js
@@ -37,6 +37,10 @@ async function main() {
       const boostBtns =  document.getElementsByClassName('boost-state-available');       
       console.log(voteBtns.length);
       
+      //close unneccessary windows
+	    $(".c-cards__close").click();
+	    $(".icon-close:not(.close)").click();
+     
       //vote for photos
       for (var btn of voteBtns){ 
                 


### PR DESCRIPTION
The bot randomly swaps pictures for you if they are suggested by GuruShots. This fix closes the suggestion windows. Maybe this will fix the random swaps.

The second line should close suggested challenge submits windows. I don't know if the bot clicks those too by accident.